### PR TITLE
マップの拡張などの特殊なレシピが正常にクラフトできない不具合を修正

### DIFF
--- a/src/main/java/life/grass/grassregulation/GrassRegulation.java
+++ b/src/main/java/life/grass/grassregulation/GrassRegulation.java
@@ -6,10 +6,6 @@ import org.bukkit.inventory.FurnaceRecipe;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 public final class GrassRegulation extends JavaPlugin {
 
     private static GrassRegulation instance;
@@ -23,30 +19,13 @@ public final class GrassRegulation extends JavaPlugin {
 
         instance = this;
         getServer().getPluginManager().registerEvents(new RegulationEvent(), this);
-        removeRecipes();
+        RecipeFilter.filter(getServer(), GrassRegulation::isAllowedRecipe);
 
     }
 
     @Override
     public void onDisable() {
         // Plugin shutdown logic
-    }
-
-    private static void removeRecipes() {
-
-        List<Recipe> backup = new ArrayList<>();
-
-        Iterator<Recipe> iterator = getInstance().getServer().recipeIterator();
-        while (iterator.hasNext()) {
-            Recipe r = iterator.next();
-            if (isAllowedRecipe(r)) {
-                backup.add(r);
-            }
-        }
-        getInstance().getServer().clearRecipes();
-        for (Recipe r : backup)
-            getInstance().getServer().addRecipe(r);
-
     }
 
     private static boolean isAllowedRecipe(Recipe recipe) {

--- a/src/main/java/life/grass/grassregulation/RecipeFilter.java
+++ b/src/main/java/life/grass/grassregulation/RecipeFilter.java
@@ -1,0 +1,136 @@
+package life.grass.grassregulation;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.inventory.Recipe;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * @author misterT2525
+ */
+class RecipeFilter {
+    private static final String OBC_PACKAGE = Bukkit.getServer().getClass().getPackage().getName();
+    private static final String NMS_PACKAGE = OBC_PACKAGE.replace("org.bukkit.craftbukkit", "net.minecraft.server");
+
+    private static Class<?> getCraftClass(String name) {
+        try {
+            return Class.forName(OBC_PACKAGE + "." + name);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Class<?> getMinecraftClass(String name) {
+        try {
+            return Class.forName(NMS_PACKAGE + "." + name);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Field getField(Class clazz, String fieldName) {
+        try {
+            Field field = clazz.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field;
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Object getFieldValue(Field field, Object object) {
+        try {
+            return field.get(object);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    private static final Method REGISTER_METHOD;
+
+    static {
+        Class<?> craftingManagerClass = getMinecraftClass("CraftingManager");
+        Class<?> keyClass = getMinecraftClass("MinecraftKey");
+        Class<?> recipeClass = getMinecraftClass("IRecipe");
+        try {
+            REGISTER_METHOD = craftingManagerClass.getDeclaredMethod("a", keyClass, recipeClass);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void register(Object key, Object recipe) {
+        try {
+            REGISTER_METHOD.invoke(null, key, recipe);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    private static final Class<?> SHAPED_CRAFT_CLASS;
+    private static final Field SHAPED_HANDLE_FIELD;
+    private static final Field SHAPED_KEY_FIELD;
+    private static final Class<?> SHAPELESS_CRAFT_CLASS;
+    private static final Field SHAPELESS_HANDLE_FIELD;
+    private static final Field SHAPELESS_KEY_FIELD;
+
+    static {
+        SHAPED_CRAFT_CLASS = RecipeFilter.getCraftClass("inventory.CraftShapedRecipe");
+        SHAPED_HANDLE_FIELD = RecipeFilter.getField(SHAPED_CRAFT_CLASS, "recipe");
+        SHAPED_KEY_FIELD = RecipeFilter.getField(SHAPED_HANDLE_FIELD.getType(), "key");
+        SHAPELESS_CRAFT_CLASS = RecipeFilter.getCraftClass("inventory.CraftShapelessRecipe");
+        SHAPELESS_HANDLE_FIELD = RecipeFilter.getField(SHAPELESS_CRAFT_CLASS, "recipe");
+        SHAPELESS_KEY_FIELD = RecipeFilter.getField(SHAPELESS_HANDLE_FIELD.getType(), "key");
+    }
+
+    private static boolean register(Recipe recipe, Field handleField, Field keyField) {
+        Object handle = RecipeFilter.getFieldValue(handleField, recipe);
+        if (handle == null) {
+            return false;
+        }
+        Object key = RecipeFilter.getFieldValue(keyField, handle);
+        RecipeFilter.register(key, handle);
+        return true;
+    }
+
+
+    private static boolean register(Recipe recipe) {
+        if (SHAPED_CRAFT_CLASS.isInstance(recipe)) {
+            return register(recipe, SHAPED_HANDLE_FIELD, SHAPED_KEY_FIELD);
+        }
+        if (SHAPELESS_CRAFT_CLASS.isInstance(recipe)) {
+            return register(recipe, SHAPELESS_HANDLE_FIELD, SHAPELESS_KEY_FIELD);
+        }
+        return false;
+    }
+
+
+    static void filter(Server server, Predicate<Recipe> predicate) {
+        List<Recipe> toAdd = new LinkedList<>();
+
+        Iterator<Recipe> iterator = server.recipeIterator();
+        while (iterator.hasNext()) {
+            Recipe recipe = iterator.next();
+            if (predicate.test(recipe)) {
+                toAdd.add(recipe);
+            }
+        }
+
+        server.clearRecipes();
+
+        toAdd.forEach(recipe -> {
+            if (!RecipeFilter.register(recipe)) {
+                server.addRecipe(recipe);
+            }
+        });
+    }
+}


### PR DESCRIPTION
CraftBukkit がレシピの登録時に新しく NMS の `ShapedRecipes` や `ShapelessRecipes` オブジェクトを生成するため、継承して特殊な処理をしているレシピが正常にクラフトできない不具合を修正しました。

`CraftShapedRecipe` と `CraftShapelessRecipe` の `recipe` フィールドに元となる NMS のオブジェクトがある場合には、それを直接登録するようにしています。
Reflection を使っているため複雑になっていますが、以下のような処理を行っています。(private なフィールドにアクセスしているため以下のコードでは動作しません)

```java
if (recipe instanceof CraftShapedRecipe) {
    ShapedRecipes internal = ((CraftShapedRecipe) recipe).recipe;
    if (internal != null) {
        CraftingManager.a(internal.key, internal);
        return;
    } 
}
// ShapelessRecipe も同じようにする

server.addRecipe(recipe); // 上記の方法で登録できなかった場合には、今までと同じように登録する
```